### PR TITLE
When serializing Uri, using Absolute URI to improve escaping of URIs…

### DIFF
--- a/SpectraLogic.SpectraRioBrokerClient/Utils/JsonConverters/UriConverter.cs
+++ b/SpectraLogic.SpectraRioBrokerClient/Utils/JsonConverters/UriConverter.cs
@@ -30,7 +30,7 @@ namespace SpectraLogic.SpectraRioBrokerClient.Utils.JsonConverters
 
         public override void WriteJson(JsonWriter writer, Uri value, JsonSerializer serializer)
         {
-            writer.WriteValue(value.ToString());
+            writer.WriteValue(value.AbsoluteUri);
         }
 
         #endregion Methods


### PR DESCRIPTION
…. because ToString() does not make any attempt.