### PR TITLE
ESCP-3680: Add VAIL agent type and update version

### DIFF
--- a/SpectraLogic.SpectraRioBrokerClient.Test/SpectraRioBrokerClientTest.cs
+++ b/SpectraLogic.SpectraRioBrokerClient.Test/SpectraRioBrokerClientTest.cs
@@ -766,6 +766,10 @@ namespace SpectraLogic.SpectraRioBrokerClient.Test
                     new ForeignJobDetails("2b6506dc-ed65-4196-ad87-c101548dad68", ForeignJobType.DIVA)
                 },
                 {
+                    new Guid("8f0496e2-4db8-4d12-96f4-8c9c889cae76"),
+                    new ForeignJobDetails("2b6506dc-ed65-4196-ad87-c101548dad66", ForeignJobType.VAIL)
+                },
+                {
                     new Guid("8f0496e2-4db8-4d12-96f4-8c9c889cae79"),
                     new ForeignJobDetails("d6a22583-ace2-426a-945f-8b59fc943ec3", ForeignJobType.UNKNOWN)
                 }

--- a/SpectraLogic.SpectraRioBrokerClient.Test/TestFiles/GetJobsResponse
+++ b/SpectraLogic.SpectraRioBrokerClient.Test/TestFiles/GetJobsResponse
@@ -54,7 +54,7 @@
         },
         "8f0496e2-4db8-4d12-96f4-8c9c889cae76": {
           "id": "2b6506dc-ed65-4196-ad87-c101548dad66",
-          "type": "DIVA"
+          "type": "VAIL"
         },
         "8f0496e2-4db8-4d12-96f4-8c9c889cae79": {
           "id": "d6a22583-ace2-426a-945f-8b59fc943ec3",

--- a/SpectraLogic.SpectraRioBrokerClient.Test/TestFiles/GetJobsResponse
+++ b/SpectraLogic.SpectraRioBrokerClient.Test/TestFiles/GetJobsResponse
@@ -52,6 +52,10 @@
           "id": "2b6506dc-ed65-4196-ad87-c101548dad68",
           "type": "DIVA"
         },
+        "8f0496e2-4db8-4d12-96f4-8c9c889cae76": {
+          "id": "2b6506dc-ed65-4196-ad87-c101548dad66",
+          "type": "DIVA"
+        },
         "8f0496e2-4db8-4d12-96f4-8c9c889cae79": {
           "id": "d6a22583-ace2-426a-945f-8b59fc943ec3",
           "type": "UNKNOWN"

--- a/SpectraLogic.SpectraRioBrokerClient/Model/ForeignJobDetails.cs
+++ b/SpectraLogic.SpectraRioBrokerClient/Model/ForeignJobDetails.cs
@@ -43,6 +43,11 @@ namespace SpectraLogic.SpectraRioBrokerClient.Model
         DIVA,
 
         /// <summary>
+        /// The vail
+        /// </summary>
+        VAIL,
+
+        /// <summary>
         /// The unknown
         /// </summary>
         UNKNOWN

--- a/SpectraLogic.SpectraRioBrokerClient/Properties/AssemblyInfo.cs
+++ b/SpectraLogic.SpectraRioBrokerClient/Properties/AssemblyInfo.cs
@@ -47,8 +47,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.2.0")]
-[assembly: AssemblyFileVersion("3.2.0")]
+[assembly: AssemblyVersion("3.2.1")]
+[assembly: AssemblyFileVersion("3.2.1")]
 
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("SpectraLogic.SpectraRioBrokerClient.Test")]


### PR DESCRIPTION
I have duplicated these two PRs that Sharon did last year:

1. Add Diva agent: 
    https://github.com/SpectraLogic/ep_net_sdk/pull/153/files
2. Update SDK version: 
    https://github.com/SpectraLogic/ep_net_sdk/pull/154

Next step will be have the Avid PAM plug-in use this updated SDK